### PR TITLE
Fix content-type in send method

### DIFF
--- a/Sources/Mailgun/Mailgun.swift
+++ b/Sources/Mailgun/Mailgun.swift
@@ -38,15 +38,13 @@ public struct Mailgun: MailgunProvider {
         
         var headers = HTTPHeaders([])
         headers.add(name: HTTPHeaderName.authorization, value: "Basic \(authKeyEncoded)")
-        let contentType = MediaType.urlEncodedForm.description
-        headers.add(name: HTTPHeaderName.contentType, value: contentType)
         
         let mailgunURL = "https://api.mailgun.net/v3/\(domain)/messages"
         
         let client = try req.make(Client.self)
         
         return client.post(mailgunURL, headers: headers) { req in
-            try req.content.encode(content)
+            try req.content.encode(content, as: MediaType.urlEncodedForm)
         }.map(to: Response.self) { response in
             switch true {
             case response.http.status.code == HTTPStatus.ok.code:


### PR DESCRIPTION
`try req.content.encode(content)` without specifying MediaType used `application/json` by default, but mailgun accept only urlEncodedForm