### PR TITLE
Replace `defaultMediaType` with `defaultContentType` in all models

### DIFF
--- a/Sources/Mailgun/Mailgun.swift
+++ b/Sources/Mailgun/Mailgun.swift
@@ -44,7 +44,7 @@ public struct Mailgun: MailgunProvider {
         let client = try req.make(Client.self)
         
         return client.post(mailgunURL, headers: headers) { req in
-            try req.content.encode(content, as: MediaType.urlEncodedForm)
+            try req.content.encode(content)
         }.map(to: Response.self) { response in
             switch true {
             case response.http.status.code == HTTPStatus.ok.code:
@@ -62,15 +62,12 @@ public struct Mailgun: MailgunProvider {
         
         var headers = HTTPHeaders([])
         headers.add(name: HTTPHeaderName.authorization, value: "Basic \(authKeyEncoded)")
-        let contentType = MediaType.urlEncodedForm.description
-        headers.add(name: HTTPHeaderName.contentType, value: contentType)
         
         let mailgunURL = "https://api.mailgun.net/v3/routes"
         
         let client = try container.make(Client.self)
         
-        return client
-            .post(mailgunURL, headers: headers) { req in
+        return client.post(mailgunURL, headers: headers) { req in
                 try req.content.encode(setup)
             }.map(to: Response.self) { (response) in
                 switch true {

--- a/Sources/Mailgun/Models/IncomingMessage.swift
+++ b/Sources/Mailgun/Models/IncomingMessage.swift
@@ -1,7 +1,7 @@
 import Vapor
 
 public struct IncomingMailgun: Content {
-    public static var defaultMediaType: MediaType = MediaType.formData
+    public static var defaultContentType: MediaType = MediaType.formData
     
     public let recipient: String
     public let sender: String

--- a/Sources/Mailgun/Models/Message.swift
+++ b/Sources/Mailgun/Models/Message.swift
@@ -2,7 +2,7 @@ import Vapor
 
 extension Mailgun {
     public struct Message: Content {
-        public static var defaultMediaType: MediaType = MediaType.urlEncodedForm
+        public static var defaultContentType: MediaType = MediaType.urlEncodedForm
         
         public typealias FullEmail = (email: String, name: String?)
         

--- a/Sources/Mailgun/Models/RouteSetup.swift
+++ b/Sources/Mailgun/Models/RouteSetup.swift
@@ -2,7 +2,7 @@ import Vapor
 import Foundation
 
 public struct RouteSetup: Content {
-    public static var defaultMediaType: MediaType = MediaType.urlEncodedForm
+    public static var defaultContentType: MediaType = MediaType.urlEncodedForm
     
     public let priority: Int
     public let description: String


### PR DESCRIPTION
It is necessary to use `req.content.encode` without specifying MediaType
Also removed redundant adding `content-type` header from `setupForwarding` method and one line-break to make `client.post` line looks in the same style as in `send` method