### PR TITLE
Implement attachments, this closes #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Note: If your private api key begins with `key-`, be sure to include it
 
 In `routes.swift`:
 
+#### Without attachments
+
 ```swift
 router.post("mail") { (req) -> Future<Response> in
     let message = Mailgun.Message(
@@ -45,6 +47,29 @@ router.post("mail") { (req) -> Future<Response> in
         subject: "Newsletter",
         text: "This is a newsletter",
         html: "<h1>This is a newsletter</h1>"
+    )
+    
+    let mailgun = try req.make(Mailgun.self)
+    return try mailgun.send(message, on: req)
+}
+```
+
+#### With attachments
+
+```swift
+router.post("mail") { (req) -> Future<Response> in
+    let fm = FileManager.default
+    guard let attachmentData = fm.contents(atPath: "/tmp/test.pdf") else {
+        throw Abort(.internalServerError)
+    }
+    let attachment = File(data: attachmentData, filename: "test.pdf")
+    let message = Mailgun.Message(
+        from: "postmaster@example.com",
+        to: "example@gmail.com",
+        subject: "Newsletter",
+        text: "This is a newsletter",
+        html: "<h1>This is a newsletter</h1>",
+        attachments: [attachment]
     )
     
     let mailgun = try req.make(Mailgun.self)

--- a/Sources/Mailgun/Models/Message.swift
+++ b/Sources/Mailgun/Models/Message.swift
@@ -2,7 +2,7 @@ import Vapor
 
 extension Mailgun {
     public struct Message: Content {
-        public static var defaultContentType: MediaType = MediaType.urlEncodedForm
+        public static var defaultContentType: MediaType = MediaType.formData
         
         public typealias FullEmail = (email: String, name: String?)
         
@@ -13,8 +13,9 @@ extension Mailgun {
         public let subject: String
         public let text: String
         public let html: String?
+        public let attachment: [File]?
         
-        public init(from: String, to: String, cc: String? = nil, bcc: String? = nil, subject: String, text: String, html: String? = nil) {
+        public init(from: String, to: String, cc: String? = nil, bcc: String? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
             self.from = from
             self.to = to
             self.cc = cc
@@ -22,9 +23,10 @@ extension Mailgun {
             self.subject = subject
             self.text = text
             self.html = html
+            self.attachment = attachments
         }
         
-        public init(from: String, to: [String], cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil) {
+        public init(from: String, to: [String], cc: [String]? = nil, bcc: [String]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
             self.from = from
             self.to = to.joined(separator: ",")
             self.cc = cc?.joined(separator: ",")
@@ -32,9 +34,10 @@ extension Mailgun {
             self.subject = subject
             self.text = text
             self.html = html
+            self.attachment = attachments
         }
         
-        public init(from: String, to: [FullEmail], cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, text: String, html: String? = nil) {
+        public init(from: String, to: [FullEmail], cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, text: String, html: String? = nil, attachments: [File]? = nil) {
             self.from = from
             self.to = to.stringArray.joined(separator: ",")
             self.cc = cc?.stringArray.joined(separator: ",")
@@ -42,6 +45,7 @@ extension Mailgun {
             self.subject = subject
             self.text = text
             self.html = html
+            self.attachment = attachments
         }
     }
 }


### PR DESCRIPTION
It is related to #14 and https://github.com/vapor/multipart/pull/28

I changed Message's `defaultContentType` to `MediaType.formData `, with it we can send messages with attachments and without.

Tested it in my project - works perfectly 🎉