### PR TITLE
Support Tags in MailgunTemplateMessage

### DIFF
--- a/Sources/Mailgun/Models/TemplateMessage.swift
+++ b/Sources/Mailgun/Models/TemplateMessage.swift
@@ -2,9 +2,9 @@ import Vapor
 
 public struct MailgunTemplateMessage: Content {
     public static var defaultContentType: HTTPMediaType = .formData
-    
+
     public typealias FullEmail = (email: String, name: String?)
-    
+
     public let from: String
     public let to: String
     public let replyTo: String?
@@ -12,12 +12,13 @@ public struct MailgunTemplateMessage: Content {
     public let bcc: String?
     public let subject: String
     public let template: String
-    public let templateData: [String:String]?
+    public let templateData: [String: String]?
     public let templateVersion: String?
     public let templateText: Bool?
     public let attachment: [File]?
     public let inline: [File]?
-    
+    public let tags: [String]?
+
     private enum CodingKeys: String, CodingKey {
         case from
         case to
@@ -31,8 +32,9 @@ public struct MailgunTemplateMessage: Content {
         case templateData = "h:X-Mailgun-Variables"
         case templateVersion = "t:version"
         case templateText = "t:text"
+        case tags = "o:tag"
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(from, forKey: .from)
@@ -43,8 +45,8 @@ public struct MailgunTemplateMessage: Content {
         try container.encode(template, forKey: .template)
         if let templateData = templateData {
             guard let jsonData = try? JSONEncoder().encode(templateData),
-                     let jsonString = String(data: jsonData, encoding: .utf8)
-                     else { throw MailgunError.encodingProblem }
+                  let jsonString = String(data: jsonData, encoding: .utf8)
+            else { throw MailgunError.encodingProblem }
             try container.encode(jsonString, forKey: .templateData)
         }
         try container.encode(templateVersion, forKey: .templateVersion)
@@ -52,9 +54,10 @@ public struct MailgunTemplateMessage: Content {
         try container.encode(text, forKey: .templateText)
         try container.encode(attachment, forKey: .attachment)
         try container.encode(inline, forKey: .inline)
+        try container.encode(tags, forKey: .tags)
     }
-    
-    public init(from: String, to: String, replyTo: String? = nil, cc: String? = nil, bcc: String? = nil, subject: String, template: String, templateData: [String:String]? = nil, templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
+
+    public init(from: String, to: String, replyTo: String? = nil, cc: String? = nil, bcc: String? = nil, subject: String, template: String, templateData: [String: String]? = nil, templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil, tags: [String]? = nil) {
         self.from = from
         self.to = to
         self.replyTo = replyTo
@@ -67,9 +70,10 @@ public struct MailgunTemplateMessage: Content {
         self.templateText = templateText
         self.attachment = attachments
         self.inline = inline
+        self.tags = tags
     }
-    
-    public init(from: String, to: [String], replyTo: String? = nil, cc: [String]? = nil, bcc: [String]? = nil, subject: String, template: String, templateData: [String:String]? = nil,  templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
+
+    public init(from: String, to: [String], replyTo: String? = nil, cc: [String]? = nil, bcc: [String]? = nil, subject: String, template: String, templateData: [String: String]? = nil, templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil, tags: [String]? = nil) {
         self.from = from
         self.to = to.joined(separator: ",")
         self.replyTo = replyTo
@@ -82,9 +86,10 @@ public struct MailgunTemplateMessage: Content {
         self.templateText = templateText
         self.attachment = attachments
         self.inline = inline
+        self.tags = tags
     }
-    
-    public init(from: String, to: [FullEmail], replyTo: String? = nil, cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, template: String, templateData: [String:String]? = nil, templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil) {
+
+    public init(from: String, to: [FullEmail], replyTo: String? = nil, cc: [FullEmail]? = nil, bcc: [FullEmail]? = nil, subject: String, template: String, templateData: [String: String]? = nil, templateVersion: String? = nil, templateText: Bool? = nil, attachments: [File]? = nil, inline: [File]? = nil, tags: [String]? = nil) {
         self.from = from
         self.to = to.stringArray.joined(separator: ",")
         self.replyTo = replyTo
@@ -97,5 +102,6 @@ public struct MailgunTemplateMessage: Content {
         self.templateText = templateText
         self.attachment = attachments
         self.inline = inline
+        self.tags = tags
     }
 }


### PR DESCRIPTION
Similar to #53, this adds tags to the `MailgunTemplateMessage` struct. Tested in Vapor 4 and Mailgun API v3